### PR TITLE
Add basic macOS file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SQLyog is a powerful GUI tool to manage MySQL and MariaDB servers and databases 
 
 SQLyog has no dependencies on runtimes (such as Microsoft .NET and Java) and database abstraction layers (such as ODBC and JDBC).
 
-SQLyog runs on Microsoft Windows. It may also run on Linux and Unix via Wine.
+SQLyog runs on Microsoft Windows. Parts of the source now support building on macOS, and it may also run on Linux and Unix via Wine.
 
 Users of SQLyog’s Community edition can get support through Webyog’s [forums for SQLyog](https://forums.webyog.com/forums/forum/sqlyog-2/). Webyog also maintains an extensive [FAQ for SQLyog](http://faq.webyog.com/) for frequently asked questions.
 

--- a/include/wyFile.h
+++ b/include/wyFile.h
@@ -33,7 +33,28 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
 #include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+/* Provide Windows style flag aliases for non Windows builds */
+#ifndef GENERIC_READ
+#define GENERIC_READ   O_RDONLY
+#endif
+#ifndef GENERIC_WRITE
+#define GENERIC_WRITE  O_WRONLY
+#endif
+#ifndef CREATE_NEW
+#define CREATE_NEW     (O_CREAT | O_EXCL)
+#endif
+#ifndef CREATE_ALWAYS
+#define CREATE_ALWAYS  (O_CREAT | O_TRUNC)
+#endif
+#ifndef OPEN_EXISTING
+#define OPEN_EXISTING  0
+#endif
+#endif
 #include <stdio.h>
 
 //#ifdef _WIN32
@@ -94,8 +115,12 @@ public:
 	
 	/******Variables************/
 	
-	//File descripter
-	HANDLE m_hfile;
+        //File descriptor/handle
+#ifdef _WIN32
+        HANDLE m_hfile;
+#else
+        int    m_hfile;
+#endif
 	wyString m_filename;
 };
 #endif

--- a/src/wyFile.cpp
+++ b/src/wyFile.cpp
@@ -22,12 +22,24 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _WIN32
 #include <io.h>
+#else
+#include <unistd.h>
+#include <limits.h>
+#ifndef MAX_PATH
+#define MAX_PATH PATH_MAX
+#endif
+#endif
 #include <stdio.h>
 
 wyFile::wyFile()
 {
-	m_hfile = NULL;
+#ifdef _WIN32
+        m_hfile = NULL;
+#else
+        m_hfile = -1;
+#endif
 }
 
 wyFile::~wyFile()
@@ -44,87 +56,125 @@ void wyFile::SetFilename(wyString * pFileName)
 wyBool
 wyFile::GetTempFilePath(wyString *pTempPath)
 {
-	wyWChar path[MAX_PATH + 1];
-			
-	if(GetTempPath(MAX_PATH, path) == 0)
-		return wyFalse;
-	
-	/*if(GetLongPathName(path, longpath, MAX_PATH) == 0) 
-	{
-		return wyFalse;
-	}*/
+#ifdef _WIN32
+        wyWChar path[MAX_PATH + 1];
 
-	pTempPath->SetAs(path);
-	return wyTrue;	
+        if(GetTempPath(MAX_PATH, path) == 0)
+                return wyFalse;
+
+        /*if(GetLongPathName(path, longpath, MAX_PATH) == 0)
+        {
+                return wyFalse;
+        }*/
+
+        pTempPath->SetAs(path);
+        return wyTrue;
+#else
+        const char* path = getenv("TMPDIR");
+        if(!path)
+                path = "/tmp";
+        pTempPath->SetAs(path);
+        return wyTrue;
+#endif
 }
 
 wyInt32
 wyFile::OpenWithPermission(wyInt32 pAccessMode, wyInt32 pCreationDisposition,wyBool inheritable)
-{	
-	wyInt32 ret = 0;
-	m_hfile = CreateFile((LPCWSTR)m_filename.GetAsWideChar(), 
-						 pAccessMode, 0, NULL, pCreationDisposition, 
-						 FILE_ATTRIBUTE_NORMAL, NULL);
+{
+        wyInt32 ret = 0;
+#ifdef _WIN32
+        m_hfile = CreateFile((LPCWSTR)m_filename.GetAsWideChar(),
+                                                 pAccessMode, 0, NULL, pCreationDisposition,
+                                                 FILE_ATTRIBUTE_NORMAL, NULL);
 
-	if(m_hfile == INVALID_HANDLE_VALUE) {
-		m_hfile = NULL;
-		ret = -1;
-	}
-	else if(inheritable)
-	{
-	//child process(plink.exe) shoudn't inherit this file.
-		if(!SetHandleInformation(m_hfile, HANDLE_FLAG_INHERIT, 0))
-		{
-		//
-		}
-	}
-	return ret;
+        if(m_hfile == INVALID_HANDLE_VALUE) {
+                m_hfile = NULL;
+                ret = -1;
+        }
+        else if(inheritable)
+        {
+        //child process(plink.exe) shoudn't inherit this file.
+                if(!SetHandleInformation(m_hfile, HANDLE_FLAG_INHERIT, 0))
+                {
+                //
+                }
+        }
+#else
+        int flags = pAccessMode | pCreationDisposition;
+        int mode = S_IRUSR | S_IWUSR;
+        m_hfile = open(m_filename.GetString(), flags, mode);
+        if(m_hfile == -1)
+                ret = -1;
+        else if(!inheritable)
+                fcntl(m_hfile, F_SETFD, FD_CLOEXEC);
+#endif
+        return ret;
 }
 
-wyInt32 
+wyInt32
 wyFile::Close()
 {
-	wyInt32 ret = 0;
-	if (m_hfile == NULL) {
-		return ret;
-	}
-	ret = CloseHandle(m_hfile);
-	m_hfile = NULL;
-	return ret;
+        wyInt32 ret = 0;
+#ifdef _WIN32
+        if (m_hfile == NULL) {
+                return ret;
+        }
+        ret = CloseHandle(m_hfile);
+        m_hfile = NULL;
+#else
+        if (m_hfile == -1) {
+                return ret;
+        }
+        ret = (close(m_hfile) == 0) ? 1 : 0;
+        m_hfile = -1;
+#endif
+        return ret;
 }
 
 wyBool
 wyFile::CheckIfFileExists()
 {
-	WIN32_FIND_DATA FindFileData;
-	HANDLE hFind;
+#ifdef _WIN32
+        WIN32_FIND_DATA FindFileData;
+        HANDLE hFind;
 
-	if (m_filename.GetLength() == 0) 
-	{
-		return wyFalse;
-	}
+        if (m_filename.GetLength() == 0)
+        {
+                return wyFalse;
+        }
 
-	hFind = FindFirstFile(m_filename.GetAsWideChar(), &FindFileData);
-	if (hFind == INVALID_HANDLE_VALUE) 
-	{
-		return wyFalse;
-	} 
-	else 
-	{
-		FindClose(hFind);
-		return wyTrue;
-	}
+        hFind = FindFirstFile(m_filename.GetAsWideChar(), &FindFileData);
+        if (hFind == INVALID_HANDLE_VALUE)
+        {
+                return wyFalse;
+        }
+        else
+        {
+                FindClose(hFind);
+                return wyTrue;
+        }
+#else
+        if (m_filename.GetLength() == 0)
+        {
+                return wyFalse;
+        }
+        return access(m_filename.GetString(), F_OK) == 0 ? wyTrue : wyFalse;
+#endif
 }
 
-wyInt32 
+wyInt32
 wyFile::RemoveFile()
 {
-	wyInt32 ret = 0;
+        wyInt32 ret = 0;
 
-	if(m_filename.GetLength())
-	{
-		ret = DeleteFile(m_filename.GetAsWideChar());
-	}
+        if(m_filename.GetLength())
+        {
+#ifdef _WIN32
+                ret = DeleteFile(m_filename.GetAsWideChar());
+#else
+                ret = (unlink(m_filename.GetString()) == 0) ? 1 : 0;
+#endif
+        }
 
-	return ret;
+        return ret;
 }


### PR DESCRIPTION
## Summary
- add macOS flag aliases and switch to int file descriptors on non-Windows builds
- implement POSIX file helpers for temp paths, open/close, existence checks and deletions
- document preliminary macOS build support

## Testing
- `make test` (fails: No rule to make target 'test')
- `g++ -c src/wyFile.cpp -Iinclude && echo 'compile-success'`


------
https://chatgpt.com/codex/tasks/task_e_68c3a8a7ccb48321ba4e4bd1115b31ca